### PR TITLE
Allow multiple TURN servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ DB_NAME=codeground
 # WebRTC STUN/TURN servers
 # Default STUN server
 STUN_SERVER_URL=stun:stun.l.google.com:19302
-# Optional TURN server configuration
-TURN_SERVER_URL=turn:your.turn.server:3478
+# Optional TURN server configuration (comma separated URLs)
+TURN_SERVER_URLS=turn:your.turn.server:3478
 TURN_USERNAME=optional-user
 TURN_PASSWORD=optional-password

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ are on the same network. To support connecting across different networks, supply
 a TURN server via environment variables. Add the following to your `.env` file:
 
 ```env
-# Address of your TURN server
-TURN_SERVER_URL=turn:your.turn.server:3478
+# Addresses of your TURN servers (comma separated)
+TURN_SERVER_URLS=turn:your.turn.server:3478
 TURN_USERNAME=optional-user
 TURN_PASSWORD=optional-password
 # Optionally override the default STUN server

--- a/README.webrtc.ko.md
+++ b/README.webrtc.ko.md
@@ -22,7 +22,7 @@ WebSocket 연결 전에 미디어 스트림을 확보하여 협상 안정성을 
 기본 예제는 공개 STUN 서버만 사용하므로 동일 네트워크 내에서 가장 잘 동작합니다. 다른 네트워크 환경에서도 연결하려면 TURN 서버 정보를 `.env` 파일에 추가합니다.
 
 ```env
-TURN_SERVER_URL=turn:your.turn.server:3478
+TURN_SERVER_URLS=turn:your.turn.server:3478
 TURN_USERNAME=optional-user
 TURN_PASSWORD=optional-password
 STUN_SERVER_URL=stun:stun.l.google.com:19302

--- a/src/app/config/config.py
+++ b/src/app/config/config.py
@@ -1,4 +1,5 @@
 import os
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
 
@@ -25,9 +26,20 @@ class Settings(BaseSettings):
         "STUN_SERVER_URL",
         "stun:stun.l.google.com:19302",
     )
+    TURN_SERVER_URLS: list[str] = []
     TURN_SERVER_URL: str | None = os.environ.get("TURN_SERVER_URL")
     TURN_USERNAME: str | None = os.environ.get("TURN_USERNAME")
     TURN_PASSWORD: str | None = os.environ.get("TURN_PASSWORD")
+
+    @model_validator(mode="after")
+    def build_turn_server_list(self) -> "Settings":
+        if not self.TURN_SERVER_URLS:
+            env_value = os.environ.get("TURN_SERVER_URLS")
+            if env_value:
+                self.TURN_SERVER_URLS = [u.strip() for u in env_value.split(",") if u.strip()]
+        if not self.TURN_SERVER_URLS and self.TURN_SERVER_URL:
+            self.TURN_SERVER_URLS = [self.TURN_SERVER_URL]
+        return self
 
 
 settings = Settings()

--- a/src/app/domain/webrtc/router/webrtc_controller.py
+++ b/src/app/domain/webrtc/router/webrtc_controller.py
@@ -42,8 +42,8 @@ manager = ConnectionManager()
 
 def build_ice_servers() -> List[dict]:
     servers = [{"urls": settings.STUN_SERVER_URL}]
-    if settings.TURN_SERVER_URL:
-        turn: dict[str, str] = {"urls": settings.TURN_SERVER_URL}
+    for url in settings.TURN_SERVER_URLS:
+        turn: dict[str, str] = {"urls": url}
         if settings.TURN_USERNAME:
             turn["username"] = settings.TURN_USERNAME
         if settings.TURN_PASSWORD:


### PR DESCRIPTION
## Summary
- add `TURN_SERVER_URLS` settings with validator for compatibility
- iterate over multiple TURN URLs when building ICE server config
- document new env variable in READMEs and `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e001669b0832e839cd3ac2b0e1c8e